### PR TITLE
fix: automatically configure analyticsId on Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@ This plugin sends [Core Web Vitals](https://web.dev/vitals/) to Vercel Analytics
 
 ## Install
 
-`npm i gatsby-plugin-vercel`
+```bash
+npm i gatsby-plugin-vercel
+```
 
 or
 
-`yarn add gatsby-plugin-vercel`
+```bash
+yarn add gatsby-plugin-vercel
+```
 
 ## Usage
 
@@ -17,8 +21,6 @@ or
 {
   resolve: 'gatsby-plugin-vercel',
   options: {
-    // (required) This env var is automatically added at build time
-    projectId: process.env.VERCEL_ANALYTICS_ID,
     // (optional) Prints metrics in the console when true
     debug: false,
   }

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -2,12 +2,12 @@ import { webVitals } from "./web-vitals";
 
 export const onClientEntry = (_, pluginOptions = {}) => {
   let options = {
-    projectId: undefined,
     debug: false,
     ...pluginOptions,
+    analyticsId: process.env.GATSBY_VERCEL_ANALYTICS_ID,
   };
 
-  if (!options.projectId) {
+  if (!options.analyticsId) {
     return null;
   }
 

--- a/src/web-vitals.js
+++ b/src/web-vitals.js
@@ -12,7 +12,7 @@ function onDebug(label, payload) {
 
 function sendToAnalytics(metric, options) {
   const body = {
-    dsn: options.projectId,
+    dsn: options.analyticsId,
     id: metric.id,
     page: location.pathname,
     href: location.href,


### PR DESCRIPTION
This PR adjusts the plugin to automatically configure the `analyticsId` as provided by Vercel.